### PR TITLE
chore(devops): enforce branch refresh before push so merges aren’t stale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,8 @@ npx tsc --noEmit
 ### Pre-push Guardrails
 - Direct pushes to `main` or `develop` are blocked by default. Create a feature branch and open a PR instead.
 - Every push automatically runs `npm run lint`, `npx tsc --noEmit`, and `npm run test:unit` (if defined). Fix failures before reattempting.
-- To override once (not recommended), set `SKIP_PRE_PUSH_CHECKS=1` to skip checks or `ALLOW_PROTECTED_BRANCH_PUSH=1` to push to a protected branch.
+- The hook fetches `origin/main` and blocks the push if your branch is missing the latest commits. Rebase/merge first, or set `SKIP_MAIN_SYNC_CHECK=1` to override once (not recommended).
+- To skip the other checks once, set `SKIP_PRE_PUSH_CHECKS=1`. To push to a protected branch, set `ALLOW_PROTECTED_BRANCH_PUSH=1`.
 - Hooks install automatically via `npm install`. Reinstall manually with `npm run setup:hooks`.
 
 ### Multi-Agent / Parallel Workflow
@@ -153,6 +154,10 @@ When several developers or Cursor agents work simultaneously, follow this branch
    ```bash
    git checkout main
    git pull --ff-only
+   ```
+   Or use the helper to refresh & create a branch in one step:
+   ```bash
+   npm run branch:new -- feature/short-description
    ```
 2. **Create or resume a feature branch per task**
    ```bash

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pr:create": "./scripts/push-and-create-pr.sh",
     "pr:cursor": "./scripts/prepare-for-cursor-pr.sh",
     "push": "./scripts/git-push-with-pr.sh",
+    "branch:new": "./scripts/git-new-branch.sh",
     "setup:hooks": "./scripts/setup-git-hooks.sh",
     "github:labels": "./scripts/github-api-helper.sh list-labels",
     "github:setup-labels": "./scripts/github-api-helper.sh setup-labels",

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -22,6 +22,28 @@ if [ "$BRANCH" = "$MAIN_BRANCH" ] || [ "$BRANCH" = "$DEVELOP_BRANCH" ]; then
   fi
 fi
 
+# Ensure branch includes the latest main changes before pushing
+if [ "${SKIP_MAIN_SYNC_CHECK:-0}" != "1" ]; then
+  MAIN_SYNC_REMOTE="${GIT_MAIN_SYNC_REMOTE:-origin}"
+  MAIN_SYNC_TARGET="${GIT_MAIN_SYNC_TARGET:-$MAIN_BRANCH}"
+
+  if git remote get-url "$MAIN_SYNC_REMOTE" >/dev/null 2>&1; then
+    echo "🔄 Refreshing '$MAIN_SYNC_REMOTE/$MAIN_SYNC_TARGET'..."
+    if git fetch "$MAIN_SYNC_REMOTE" "$MAIN_SYNC_TARGET" --quiet; then
+      if ! git merge-base --is-ancestor "$MAIN_SYNC_REMOTE/$MAIN_SYNC_TARGET" HEAD; then
+        echo "❌ Branch '$BRANCH' is missing the latest commits from '$MAIN_SYNC_REMOTE/$MAIN_SYNC_TARGET'."
+        echo "   Rebase or merge the latest '$MAIN_SYNC_TARGET' before pushing:"
+        echo "     git fetch $MAIN_SYNC_REMOTE $MAIN_SYNC_TARGET"
+        echo "     git rebase $MAIN_SYNC_REMOTE/$MAIN_SYNC_TARGET"
+        echo "   Override once with SKIP_MAIN_SYNC_CHECK=1 (not recommended)."
+        exit 1
+      fi
+    else
+      echo "⚠️  Unable to fetch '$MAIN_SYNC_REMOTE/$MAIN_SYNC_TARGET'; skipping freshness check."
+    fi
+  fi
+fi
+
 # Run verification steps unless explicitly skipped
 if [ "${SKIP_PRE_PUSH_CHECKS:-0}" != "1" ]; then
   if command -v npm >/dev/null 2>&1; then

--- a/scripts/git-new-branch.sh
+++ b/scripts/git-new-branch.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Refresh main (or specified base) and create a new branch safely.
+# Usage: ./scripts/git-new-branch.sh <branch-name> [base-branch] [remote]
+
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <branch-name> [base-branch] [remote]" >&2
+  exit 1
+fi
+
+BRANCH_NAME="$1"
+BASE_BRANCH="${2:-main}"
+REMOTE_NAME="${3:-origin}"
+
+# Ensure clean working tree before switching branches
+if [ -n "$(git status --porcelain)" ]; then
+  echo "❌ Working tree has uncommitted changes."
+  echo "   Commit, stash, or clean your tree before creating a new branch."
+  exit 1
+fi
+
+# Ensure remote exists
+if ! git remote get-url "$REMOTE_NAME" >/dev/null 2>&1; then
+  echo "❌ Remote '$REMOTE_NAME' not found."
+  exit 1
+fi
+
+echo "🔄 Fetching latest '$BASE_BRANCH' from '$REMOTE_NAME'..."
+if ! git fetch "$REMOTE_NAME" "$BASE_BRANCH" --prune --prune-tags >/dev/null 2>&1; then
+  echo "❌ Failed to fetch '$BASE_BRANCH' from '$REMOTE_NAME'."
+  exit 1
+fi
+
+echo "📦 Updating local '$BASE_BRANCH'..."
+git checkout "$BASE_BRANCH" >/dev/null 2>&1
+git pull --ff-only "$REMOTE_NAME" "$BASE_BRANCH"
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  echo "⚠️  Local branch '$BRANCH_NAME' already exists. Switching to it."
+  git checkout "$BRANCH_NAME"
+else
+  echo "🌱 Creating new branch '$BRANCH_NAME' based on '$BASE_BRANCH'..."
+  git checkout -b "$BRANCH_NAME"
+fi
+
+echo "✅ Ready on branch '$BRANCH_NAME'."
+

--- a/scripts/push-and-create-pr.sh
+++ b/scripts/push-and-create-pr.sh
@@ -14,6 +14,22 @@ if [ "$CURRENT_BRANCH" = "$BASE_BRANCH" ] || [ "$CURRENT_BRANCH" = "develop" ]; 
   exit 1
 fi
 
+# Ensure we're up-to-date with the latest base branch before proceeding
+if git remote get-url "$REMOTE" >/dev/null 2>&1; then
+  echo "🔄 Refreshing '$REMOTE/$BASE_BRANCH'..."
+  if git fetch "$REMOTE" "$BASE_BRANCH" --quiet; then
+    if ! git merge-base --is-ancestor "$REMOTE/$BASE_BRANCH" "$CURRENT_BRANCH"; then
+      echo "❌ Branch '$CURRENT_BRANCH' is missing the latest commits from '$REMOTE/$BASE_BRANCH'."
+      echo "   Rebase or merge the latest '$BASE_BRANCH' before pushing:"
+      echo "     git fetch $REMOTE $BASE_BRANCH"
+      echo "     git rebase $REMOTE/$BASE_BRANCH"
+      exit 1
+    fi
+  else
+    echo "⚠️  Unable to fetch '$REMOTE/$BASE_BRANCH'; continuing without freshness check."
+  fi
+fi
+
 # Check if GitHub CLI is installed
 if ! command -v gh >/dev/null 2>&1; then
   echo "❌ GitHub CLI (gh) is not installed"


### PR DESCRIPTION
## Summary
- add npm run branch:new helper to auto-refresh base and create feature branches
- enforce main-sync check inside pre-push and PR helper scripts to block outdated pushes
- document new guardrails and override env vars in CONTRIBUTING

## Testing
- not run (shell/doc updates only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add branch freshness checks to push/PR flows and introduce `branch:new` helper; update docs accordingly.
> 
> - **Git hooks & scripts**:
>   - Enforce up-to-date with `main` before push/PR:
>     - `scripts/git-hooks/pre-push`: fetch `origin/main` (configurable) and block if not ancestor; supports `SKIP_MAIN_SYNC_CHECK=1`.
>     - `scripts/git-push-with-pr.sh` and `scripts/push-and-create-pr.sh`: fetch/check base branch and block outdated branches.
>   - Auto PR description generation logic retained; minor robustness tweaks.
>   - New helper `scripts/git-new-branch.sh`: refresh base and create/switch branch safely; added npm script `branch:new`.
> - **Docs**:
>   - `CONTRIBUTING.md`: document pre-push guardrails, override env vars, and new `branch:new` workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba18c159bb15055236619d30053fe90d572b3b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->