### PR TITLE
chore(devops): block commits on protected branches so history stays clean

### DIFF
--- a/scripts/git-hooks/prepare-commit-msg
+++ b/scripts/git-hooks/prepare-commit-msg
@@ -1,26 +1,38 @@
 #!/bin/sh
-# Prefill commit messages based on branch naming convention.
+# Guardrails: block commits on protected branches and prefill messages from branch names.
 
 set -eu
 
 COMMIT_MSG_FILE="$1"
 COMMIT_SOURCE="${2:-}"
 
-# Skip for merge, squash, or rebase commits that already have templates
+BRANCH="$(git branch --show-current 2>/dev/null || printf '')"
+MAIN_BRANCH="main"
+DEVELOP_BRANCH="develop"
+
+# Block commits directly on protected branches (unless explicitly overridden)
+if [ "${ALLOW_PROTECTED_BRANCH_COMMIT:-0}" != "1" ]; then
+  if [ "$BRANCH" = "$MAIN_BRANCH" ] || [ "$BRANCH" = "$DEVELOP_BRANCH" ]; then
+    echo "❌ Commits directly on '$BRANCH' are blocked by repository guardrails."
+    echo "   Create a feature branch and commit there instead."
+    echo "   Override once with: ALLOW_PROTECTED_BRANCH_COMMIT=1 git commit ..."
+    exit 1
+  fi
+fi
+
+# Skip prefill for merge/squash/rebase commits that already have messages
 case "$COMMIT_SOURCE" in
   merge|squash|commit)
     exit 0
     ;;
 esac
 
-# Only act if commit message is empty / whitespace
+# Only prefill if commit message is empty / whitespace
 if [ -s "$COMMIT_MSG_FILE" ]; then
   if [ -n "$(tr -d '[:space:]' < "$COMMIT_MSG_FILE")" ]; then
     exit 0
   fi
 fi
-
-BRANCH="$(git branch --show-current 2>/dev/null || printf '')"
 
 BRANCH_PATTERN='^(feat|fix|chore|docs|refactor|test)/[a-z0-9]+(-[a-z0-9]+){2,}$'
 if ! printf "%s" "$BRANCH" | grep -Eq "$BRANCH_PATTERN"; then
@@ -33,5 +45,4 @@ TYPE_LOWER=$(printf "%s" "$TYPE_PART" | tr '[:upper:]' '[:lower:]')
 REST_MESSAGE=$(printf "%s" "$REST_PART" | tr '-' ' ')
 
 printf "%s: %s\n" "$TYPE_LOWER" "$REST_MESSAGE" > "$COMMIT_MSG_FILE"
-
 


### PR DESCRIPTION
## Description

Add a `prepare-commit-msg` hook that blocks commits directly to protected branches (`main`, `develop`) unless explicitly overridden.

**Key changes**
- create `scripts/git-hooks/prepare-commit-msg` with guardrail logic
- allow bypassing via `ALLOW_PROTECTED_BRANCH_COMMIT=1` for emergencies
- reuse existing environment toggle pattern for consistency

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Developer experience
- [ ] Documentation update

## Changes Made

### Code Changes
- scripts/git-hooks/prepare-commit-msg (new hook)

## Testing
- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `npm run --if-present test:unit`
- [x] Manual commit attempt on `main` (blocked as expected)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `prepare-commit-msg` hook that blocks commits on `main`/`develop` (overridable) and auto-prefills messages from branch names when applicable.
> 
> - **Git hooks**:
>   - **`scripts/git-hooks/prepare-commit-msg`**:
>     - Blocks commits on protected branches (`main`, `develop`) unless `ALLOW_PROTECTED_BRANCH_COMMIT=1` is set.
>     - Skips for merge/squash/commit messages and when an existing message is non-empty.
>     - Auto-prefills commit message from branch names matching `^(feat|fix|chore|docs|refactor|test)/...` by converting dashes to spaces and lowercasing the type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c5f275578e3a75ba1fb90bd872510c3e8f51d8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->