### PR TITLE
fix(devops): append --force-with-lease after auto rebase to protect teammates

### DIFF
--- a/scripts/git-push-with-pr.sh
+++ b/scripts/git-push-with-pr.sh
@@ -86,11 +86,14 @@ fi
 
 # Perform the actual git push
 echo "🚀 Pushing branch..."
-PUSH_CMD=(git push "$@")
+PUSH_CMD=(git push)
 
 if [ "$REBASE_PERFORMED" -eq 1 ]; then
   echo "ℹ️  Force-with-lease enabled because branch was rebased."
-  PUSH_CMD=(git push --force-with-lease "$@")
+  PUSH_CMD+=("$@")
+  PUSH_CMD+=(--force-with-lease)
+else
+  PUSH_CMD+=("$@")
 fi
 
 if "${PUSH_CMD[@]}"; then

--- a/scripts/push-and-create-pr.sh
+++ b/scripts/push-and-create-pr.sh
@@ -80,13 +80,16 @@ fi
 
 echo ""
 echo "🚀 Pushing branch to $REMOTE..."
-PUSH_ARGS=(-u "$REMOTE" "$CURRENT_BRANCH")
+PUSH_CMD=(git push)
+
 if [ "$REBASE_PERFORMED" -eq 1 ]; then
   echo "ℹ️  Force-with-lease enabled because branch was rebased."
-  PUSH_ARGS=(--force-with-lease -u "$REMOTE" "$CURRENT_BRANCH")
+  PUSH_CMD+=(-u "$REMOTE" "$CURRENT_BRANCH" --force-with-lease)
+else
+  PUSH_CMD+=(-u "$REMOTE" "$CURRENT_BRANCH")
 fi
 
-git push "${PUSH_ARGS[@]}"
+"${PUSH_CMD[@]}"
 
 echo ""
 echo "📋 Creating pull request..."


### PR DESCRIPTION
## Description

Ensure push helper scripts force-with-lease after auto-rebasing so rebased branches can be pushed cleanly.

**Key changes**
- `scripts/git-push-with-pr.sh`: track when auto-rebase runs and swap push command to `git push --force-with-lease`
- `scripts/push-and-create-pr.sh`: same force-with-lease logic for its managed push
- keep `SKIP_AUTO_REBASE` escape hatch and clean-tree checks

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- scripts/git-push-with-pr.sh
- scripts/push-and-create-pr.sh

## Testing
- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `npm run --if-present test:unit`
- [x] Manual: verified script pushes succeed after auto-rebase using `--force-with-lease`

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-rebase feature branches onto the base and push with --force-with-lease when rebased, with safety checks and an opt-out flag.
> 
> - **Scripts**:
>   - `scripts/git-push-with-pr.sh`:
>     - Auto-fetch and rebase onto `origin/main` when behind (skip via `SKIP_AUTO_REBASE`, abort if working tree dirty).
>     - Track rebase via `REBASE_PERFORMED`; switch push to `git push --force-with-lease` when rebased.
>   - `scripts/push-and-create-pr.sh`:
>     - Same auto-rebase flow and safeguards.
>     - Push uses `--force-with-lease` when a rebase occurred.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 534691c44df36b0dd2ea8e5ab614cdde99c8d4e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->