### PR TITLE
test: seed matching integration so ranked results stay correct

### DIFF
--- a/NEON_SETUP.md
+++ b/NEON_SETUP.md
@@ -57,7 +57,16 @@
      DATABASE_URL="postgresql://user:password@ep-xxx-xxx.region.aws.neon.tech/neondb?sslmode=require&schema=public"
      ```
 
-2. **Verify pgvector is enabled:**
+2. **(Recommended) Create a dedicated test branch/database:**
+   - In the Neon dashboard, go to **Branches → New branch** and name it `tests` (or similar).
+   - Copy the connection string for that branch.
+   - Update `.env.test.local` (create from `env.test.example`) with:
+     ```env
+     TEST_DATABASE_URL="postgresql://user:password@ep-xxx-xxx.region.aws.neon.tech/neondb?sslmode=require&schema=public"
+     ```
+   - The integration tests will create isolated schemas on this branch and tear them down automatically.
+
+3. **Verify pgvector is enabled:**
    - Neon comes with pgvector pre-installed
    - Your migration will enable it automatically
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -56,6 +56,11 @@ npx prisma studio
 
 ## Debugging Tips
 
+### Configure Integration Tests
+- Copy `env.test.example` to `.env.test.local` and update `TEST_DATABASE_URL` with a database/branch safe for destructive resets.
+- The integration suite automatically creates and drops isolated schemas, but it needs credentials with permission to create schemas.
+- If `TEST_DATABASE_URL` is not provided, the tests fall back to `DATABASE_URL`; ensure this points to a non-production database before running `npm run test:integration`.
+
 ### Check Terminal Logs
 Look for these log messages:
 - `📧 Attempting to send email:` - Email sending started

--- a/env.example
+++ b/env.example
@@ -1,5 +1,8 @@
 # Database
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DBNAME?schema=public"
+# Optional: dedicate an isolated database/branch for automated tests
+# If omitted, integration tests fall back to DATABASE_URL
+TEST_DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/TEST_DBNAME?schema=public"
 
 # NextAuth
 NEXTAUTH_SECRET="generate-a-random-secret-here"

--- a/env.test.example
+++ b/env.test.example
@@ -1,0 +1,2 @@
+TEST_DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/TEST_DBNAME?schema=public"
+

--- a/tests/integration/match-findMatchesFor.test.ts
+++ b/tests/integration/match-findMatchesFor.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  getTestPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from "../helpers/db";
+
+const hasDatabaseUrl = Boolean(process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL);
+const describeIfDatabaseConfigured = hasDatabaseUrl ? describe : describe.skip;
+
+const prismaHolder: { prisma: PrismaClient | null } = { prisma: null };
+
+vi.mock("@/lib/db", () => ({
+  get prisma() {
+    if (!prismaHolder.prisma) {
+      throw new Error("Prisma client requested before test database setup.");
+    }
+    return prismaHolder.prisma;
+  },
+}));
+
+const toVector = (values: number[]) => Buffer.from(new Float32Array(values).buffer);
+
+describeIfDatabaseConfigured("findMatchesFor integration", () => {
+  let findMatchesFor: typeof import("@/lib/match").findMatchesFor;
+
+  beforeAll(async () => {
+    const { prisma } = await setupTestDatabase();
+    prismaHolder.prisma = prisma;
+    ({ findMatchesFor } = await import("@/lib/match"));
+  }, 60000);
+
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    prismaHolder.prisma = null;
+    await teardownTestDatabase();
+  });
+
+  it("returns counterpart role embeddings ordered by cosine similarity", async () => {
+    const prisma = getTestPrismaClient();
+
+    const ceo = await prisma.user.create({
+      data: { email: "ceo@example.com", role: "CEO" },
+    });
+
+    await prisma.embedding.create({
+      data: {
+        userId: ceo.id,
+        role: "CEO",
+        source: "summary",
+        vector: toVector([1, 0]),
+      },
+    });
+
+    const perfectMatch = await prisma.user.create({
+      data: { email: "cto-perfect@example.com", role: "CTO" },
+    });
+    await prisma.embedding.create({
+      data: {
+        userId: perfectMatch.id,
+        role: "CTO",
+        source: "summary",
+        vector: toVector([1, 0]),
+      },
+    });
+
+    const closeMatch = await prisma.user.create({
+      data: { email: "cto-close@example.com", role: "CTO" },
+    });
+    await prisma.embedding.create({
+      data: {
+        userId: closeMatch.id,
+        role: "CTO",
+        source: "summary",
+        vector: toVector([1, 1]),
+      },
+    });
+
+    const ignoredDifferentSource = await prisma.user.create({
+      data: { email: "cto-other-source@example.com", role: "CTO" },
+    });
+    await prisma.embedding.create({
+      data: {
+        userId: ignoredDifferentSource.id,
+        role: "CTO",
+        source: "full",
+        vector: toVector([0, 1]),
+      },
+    });
+
+    const ignoredSameRole = await prisma.user.create({
+      data: { email: "ceo-other@example.com", role: "CEO" },
+    });
+    await prisma.embedding.create({
+      data: {
+        userId: ignoredSameRole.id,
+        role: "CEO",
+        source: "summary",
+        vector: toVector([0, 1]),
+      },
+    });
+
+    const matches = await findMatchesFor(ceo.id, "CEO");
+
+    expect(matches.map((m) => m.userId)).toEqual([perfectMatch.id, closeMatch.id]);
+    expect(matches[0]?.score).toBeCloseTo(1, 5);
+    expect(matches[1]?.score).toBeCloseTo(0.7071, 4);
+  });
+});
+
+


### PR DESCRIPTION
## Summary
- add a focused integration test for `findMatchesFor` that exercises vector matching order
- introduce `TEST_DATABASE_URL` support and sample `.env.test` template for isolated test branches
- document Neon/test database setup steps in `TESTING.md` and `NEON_SETUP.md`

## Testing
- [ ] npm run test:unit *(blocked: no dedicated Neon test branch in this environment)*
- [ ] npm run test:integration *(requires configured `TEST_DATABASE_URL`)*
- [ ] Manual verification *(blocked: cannot provision isolated database here)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an integration test for `findMatchesFor`, introduces `TEST_DATABASE_URL` with env templates, and updates Neon/testing docs.
> 
> - **Tests**:
>   - Add `tests/integration/match-findMatchesFor.test.ts` to verify counterpart role matching ordered by cosine similarity and ignore non-matching sources/roles.
> - **Config/Env**:
>   - Introduce `TEST_DATABASE_URL` support; add `env.test.example` and document fallback to `DATABASE_URL`.
>   - Update `env.example` with `TEST_DATABASE_URL` guidance.
> - **Docs**:
>   - Update `NEON_SETUP.md` to recommend a dedicated Neon test branch and `.env.test.local` config.
>   - Update `TESTING.md` with integration test configuration instructions and cautions about destructive resets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fedea5985c736b5f5f9cb1810f0492dfcdd4d1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->