### PR TITLE
test: add local Playwright smoke harness to mimic production onboarding

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL;
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000,
+  },
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+});
+
+

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL;
+
+test.skip(!baseURL, "Set PLAYWRIGHT_BASE_URL to run e2e smoke tests against a live environment.");
+
+test.describe("Landing page smoke test", () => {
+  test("shows hero content and auth links", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "FounderFinder" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sign up" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+  });
+});
+
+


### PR DESCRIPTION
## Summary
1. add repository-level Playwright config so we can run smoke tests against configurable base URLs.
2. add initial smoke spec that verifies the landing page renders hero text and auth links.

## Testing
1. npm run test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Playwright configuration and an initial E2E smoke test for the landing page with a configurable base URL.
> 
> - **E2E Testing**:
>   - **Config** (`playwright.config.ts`): repository-level Playwright setup with `testDir`, `baseURL` via `PLAYWRIGHT_BASE_URL`, retries, trace, video, and Chromium desktop project.
>   - **Smoke Test** (`tests/e2e/smoke.spec.ts`): verifies landing page shows "FounderFinder" heading and "Sign up"/"Sign in" links; test suite skipped if `PLAYWRIGHT_BASE_URL` is unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37611b3c081728bfbfb60b81cefd505a67e240ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->