### PR TITLE
test: extend env & AI unit suites to fail fast on missing secrets

### DIFF
--- a/tests/unit/ai.test.ts
+++ b/tests/unit/ai.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("AI helpers", () => {
+  it("returns empty strings when OpenAI API key is not present", async () => {
+    const { summarizeProfile, buildMatchRationale } = await import("@/lib/ai");
+
+    await expect(
+      summarizeProfile({ role: "CEO", structured: { headline: "CTO wanted" }, freeText: "Details" })
+    ).resolves.toBe("");
+
+    await expect(buildMatchRationale("Summary A", "Summary B")).resolves.toBe("");
+  });
+
+  it("delegates to OpenAI chat completions when configured", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+
+    const summaryMock = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "Short summary" } }],
+    });
+
+    const rationaleMock = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "• Point A\n• Point B" } }],
+    });
+
+    const createMock = vi.fn()
+      .mockImplementationOnce(summaryMock)
+      .mockImplementationOnce(rationaleMock);
+
+    class OpenAIMock {
+      chat = {
+        completions: {
+          create: createMock,
+        },
+      };
+    }
+
+    vi.doMock("openai", () => ({ default: OpenAIMock }));
+
+    const { summarizeProfile, buildMatchRationale } = await import("@/lib/ai");
+
+    await expect(
+      summarizeProfile({ role: "CTO", structured: { skills: ["TypeScript"] }, freeText: "Great engineer" })
+    ).resolves.toBe("Short summary");
+
+    await expect(buildMatchRationale("CEO summary", "CTO summary")).resolves.toBe("• Point A\n• Point B");
+
+    expect(summaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "You are a concise recruiter summarizer." },
+          expect.objectContaining({ role: "user", content: expect.stringContaining("Summarize this CTO") }),
+        ],
+        temperature: 0.2,
+      })
+    );
+
+    expect(rationaleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "Explain the match succinctly in 3 bullet points." },
+          { role: "user", content: "CEO: CEO summary\nCTO: CTO summary" },
+        ],
+        temperature: 0.2,
+      })
+    );
+  });
+});
+
+

--- a/tests/unit/embeddings.test.ts
+++ b/tests/unit/embeddings.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("embeddings helpers", () => {
+  it("returns empty bytes and skips persistence when OpenAI API key is missing", async () => {
+    const prismaMock = {
+      embedding: {
+        create: vi.fn(),
+      },
+    };
+
+    vi.doMock("@/lib/db", () => ({ prisma: prismaMock }));
+
+    const { embed, upsertEmbedding } = await import("@/lib/embeddings");
+
+    const bytes = await embed("Hello world");
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(0);
+
+    await upsertEmbedding("user-1", "CEO", "Hello world", "summary");
+    expect(prismaMock.embedding.create).not.toHaveBeenCalled();
+  });
+
+  it("stores generated embeddings when OpenAI API key is configured", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+
+    const createMock = vi.fn().mockResolvedValue({
+      data: [{ embedding: [0.5, 0.25] }],
+    });
+
+    class OpenAIMock {
+      embeddings = { create: createMock };
+    }
+
+    vi.doMock("openai", () => ({ default: OpenAIMock }));
+
+    const prismaMock = {
+      embedding: {
+        create: vi.fn(),
+      },
+    };
+
+    vi.doMock("@/lib/db", () => ({ prisma: prismaMock }));
+
+    const { embed, upsertEmbedding } = await import("@/lib/embeddings");
+
+    const bytes = await embed("Generate me");
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+
+    await upsertEmbedding("user-2", "CTO", "Generate me", "summary");
+
+    expect(createMock).toHaveBeenCalledWith({
+      model: "text-embedding-3-small",
+      input: "Generate me",
+    });
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(prismaMock.embedding.create).toHaveBeenCalledTimes(1);
+    const payload = prismaMock.embedding.create.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      data: {
+        userId: "user-2",
+        role: "CTO",
+        source: "summary",
+      },
+    });
+
+    const storedBuffer = payload.data.vector as Buffer;
+    const restored = new Float32Array(storedBuffer.buffer, storedBuffer.byteOffset, storedBuffer.byteLength / 4);
+    expect(Array.from(restored)).toEqual([0.5, 0.25]);
+  });
+});
+
+

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+
+const requiredEnv = {
+  DATABASE_URL: "postgresql://user:pass@localhost:5432/db",
+  NEXTAUTH_SECRET: "secret",
+  NEXTAUTH_URL: "http://localhost:3000",
+  RESEND_API_KEY: "resend-key",
+  EMAIL_FROM: "founder@example.com",
+  OPENAI_API_KEY: "openai-key",
+  UPSTASH_REDIS_REST_URL: "https://upstash.io",
+  UPSTASH_REDIS_REST_TOKEN: "redis-token",
+};
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+});
+
+async function importEnvModule() {
+  return import("@/lib/env");
+}
+
+describe("env schema", () => {
+  it("parses environment variables when all required values are provided", async () => {
+    for (const [key, value] of Object.entries(requiredEnv)) {
+      vi.stubEnv(key, value);
+    }
+
+    const { env } = await importEnvModule();
+
+    expect(env).toMatchObject({
+      DATABASE_URL: requiredEnv.DATABASE_URL,
+      NEXTAUTH_SECRET: requiredEnv.NEXTAUTH_SECRET,
+      RESEND_API_KEY: requiredEnv.RESEND_API_KEY,
+      EMAIL_FROM: requiredEnv.EMAIL_FROM,
+      OPENAI_API_KEY: requiredEnv.OPENAI_API_KEY,
+    });
+  });
+
+  it("throws a validation error when a required variable is missing", async () => {
+    for (const [key, value] of Object.entries(requiredEnv)) {
+      if (key === "NEXTAUTH_SECRET") {
+        vi.stubEnv(key, "");
+      } else {
+        vi.stubEnv(key, value);
+      }
+    }
+
+    await expect(importEnvModule()).rejects.toThrow(/NEXTAUTH_SECRET/i);
+  });
+});
+
+

--- a/tests/unit/rateLimit.test.ts
+++ b/tests/unit/rateLimit.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("limit helper", () => {
+  it("returns success when redis is not configured", async () => {
+    vi.unstubAllEnvs();
+
+    const { limit } = await import("@/lib/rateLimit");
+
+    await expect(limit("user-1")).resolves.toEqual({ success: true });
+    await expect(limit("user-1", "auth")).resolves.toEqual({ success: true });
+  });
+
+  it("delegates to Upstash ratelimit when redis credentials are provided", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "token");
+
+    const limitSpy = vi.fn().mockResolvedValue({ success: false, reason: "throttled" });
+    const slidingWindowSpy = vi.fn().mockReturnValue("limiter");
+
+    const ratelimitInstances: Array<{ options: any }> = [];
+
+    const RedisMock = vi.fn(function RedisMock(this: any, config) {
+      (this as any).config = config;
+    });
+
+    vi.doMock("@upstash/redis", () => ({
+      Redis: RedisMock,
+    }));
+
+    vi.doMock("@upstash/ratelimit", () => {
+      const Ratelimit = vi.fn(function Ratelimit(this: any, options) {
+        ratelimitInstances.push({ options });
+        (this as any).limit = limitSpy;
+      }) as unknown as typeof import("@upstash/ratelimit").Ratelimit;
+
+      (Ratelimit as any).slidingWindow = slidingWindowSpy;
+
+      return { Ratelimit };
+    });
+
+    const { limit } = await import("@/lib/rateLimit");
+
+    expect(slidingWindowSpy).toHaveBeenNthCalledWith(1, 5, "10 m");
+    expect(slidingWindowSpy).toHaveBeenNthCalledWith(2, 60, "10 m");
+    expect(ratelimitInstances).toHaveLength(2);
+    expect(ratelimitInstances[0]?.options).toMatchObject({ prefix: "ff:auth" });
+    expect(ratelimitInstances[1]?.options).toMatchObject({ prefix: "ff:api" });
+
+    await limit("api-user"); // defaults to api limiter (second constructor call)
+    await limit("auth-user", "auth");
+
+    expect(limitSpy).toHaveBeenCalledTimes(2);
+    expect(limitSpy).toHaveBeenNthCalledWith(1, "api-user");
+    expect(limitSpy).toHaveBeenNthCalledWith(2, "auth-user");
+  });
+});
+
+


### PR DESCRIPTION
## Summary
- add focused unit suites covering env schema validation, rate limiter bootstrapping, OpenAI embedding helper, and AI summarization fallbacks
- ensure tests handle missing secret scenarios and mocked third-party constructors without hitting external services

## Testing
- npm run lint
- npx tsc --noEmit
- npm run test:unit
- npm run test:e2e:smoke

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds unit tests validating env parsing, Upstash rate limiter wiring, and OpenAI chat/embedding helpers (with/without API key) including persistence behavior.
> 
> - **Tests (unit)**:
>   - **AI helpers (`tests/unit/ai.test.ts`)**:
>     - Verifies empty outputs without `OPENAI_API_KEY`.
>     - Mocks OpenAI chat completions and asserts model/messages/temperature and outputs.
>   - **Embeddings (`tests/unit/embeddings.test.ts`)**:
>     - Ensures empty bytes and no DB writes without `OPENAI_API_KEY`.
>     - Mocks OpenAI embeddings; asserts model/input, byte conversion, and Prisma `embedding.create` payload.
>   - **Env schema (`tests/unit/env.test.ts`)**:
>     - Parses required vars; errors when `NEXTAUTH_SECRET` missing.
>   - **Rate limiting (`tests/unit/rateLimit.test.ts`)**:
>     - Succeeds when Redis not configured.
>     - Mocks Upstash clients; asserts sliding window config, prefixes, and limiter selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1562fb32e9b6dd82b27c097ea4978b839f1fca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->