### PR TITLE
test: add onboarding & matching integrations so API regressions surface

### DIFF
--- a/tests/integration/api-interview-submit.test.ts
+++ b/tests/integration/api-interview-submit.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  getTestPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from "../helpers/db";
+
+const hasDatabaseUrl = Boolean(process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL);
+const describeIfDatabaseConfigured = hasDatabaseUrl ? describe : describe.skip;
+
+const prismaHolder: { prisma: PrismaClient | null } = { prisma: null };
+const authMock = vi.fn();
+const limitMock = vi.fn();
+const summarizeMock = vi.fn();
+const upsertEmbeddingMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  get prisma() {
+    if (!prismaHolder.prisma) {
+      throw new Error("Prisma client requested before test database setup.");
+    }
+    return prismaHolder.prisma;
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  auth: () => authMock(),
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  limit: (key: string, kind?: "auth" | "api") => limitMock(key, kind),
+}));
+
+vi.mock("@/lib/ai", () => ({
+  summarizeProfile: (...args: Parameters<typeof summarizeMock>) => summarizeMock(...args),
+}));
+
+vi.mock("@/lib/embeddings", () => ({
+  upsertEmbedding: (...args: Parameters<typeof upsertEmbeddingMock>) =>
+    upsertEmbeddingMock(...args),
+}));
+
+describeIfDatabaseConfigured("POST /api/interview/submit", () => {
+  let handler: typeof import("@/app/api/interview/submit/route").POST;
+
+  beforeAll(async () => {
+    const { prisma } = await setupTestDatabase();
+    prismaHolder.prisma = prisma;
+    ({ POST: handler } = await import("@/app/api/interview/submit/route"));
+  }, 60000);
+
+  afterEach(async () => {
+    authMock.mockReset();
+    limitMock.mockReset();
+    summarizeMock.mockReset();
+    upsertEmbeddingMock.mockReset();
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    prismaHolder.prisma = null;
+    await teardownTestDatabase();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+    limitMock.mockResolvedValue({ success: true });
+
+    const request = new Request("http://localhost/api/interview/submit", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({ data: { email: "member@example.com", role: "CEO" } });
+
+    authMock.mockResolvedValue({ userId: user.id });
+    limitMock.mockResolvedValue({ success: false });
+
+    const request = new Request("http://localhost/api/interview/submit", {
+      method: "POST",
+      body: JSON.stringify({ role: "CEO", structured: {}, freeText: "" }),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "Rate limit" });
+  });
+
+  it("persists CEO interview data and triggers summary + embedding", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({
+      data: { email: "ceo@example.com", role: "CEO" },
+    });
+
+    authMock.mockResolvedValue({ userId: user.id, role: "CEO" });
+    limitMock.mockResolvedValue({ success: true });
+    summarizeMock.mockResolvedValue("Concise CEO summary");
+    upsertEmbeddingMock.mockResolvedValue(undefined);
+
+    const payload = {
+      role: "CEO" as const,
+      structured: {
+        name: "Alice",
+        location: "NYC",
+        stage: "Seed",
+        domain: "AI",
+        description: "Building cofounder matching",
+        equity_offer: "5%",
+        salary_offer: "$80k",
+      },
+      freeText: "I love empowering CTOs.",
+    };
+
+    const request = new Request("http://localhost/api/interview/submit", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+
+    const interview = await prisma.interviewResponse.findFirst({ where: { userId: user.id } });
+    expect(interview).not.toBeNull();
+    expect(interview?.structured).toMatchObject(payload.structured);
+
+    const profile = await prisma.profile.findUnique({ where: { userId: user.id } });
+    expect(profile).toMatchObject({
+      name: "Alice",
+      location: "NYC",
+    });
+
+    const startup = await prisma.startup.findUnique({ where: { userId: user.id } });
+    expect(startup).toMatchObject({
+      stage: "Seed",
+      domain: "AI",
+      description: "Building cofounder matching",
+      equity_offer: "5%",
+      salary_offer: "$80k",
+    });
+
+    const userRecord = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(userRecord?.onboarded).toBe(true);
+
+    const summary = await prisma.profileSummary.findUnique({ where: { userId: user.id } });
+    expect(summary?.ai_summary_text).toBe("Concise CEO summary");
+
+    expect(summarizeMock).toHaveBeenCalledWith({
+      role: "CEO",
+      structured: payload.structured,
+      freeText: payload.freeText,
+    });
+    expect(upsertEmbeddingMock).toHaveBeenCalledWith(user.id, "CEO", "Concise CEO summary", "summary");
+  });
+
+  it("persists CTO interview data and triggers summary + embedding", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({
+      data: { email: "cto@example.com", role: "CTO" },
+    });
+
+    authMock.mockResolvedValue({ userId: user.id, role: "CTO" });
+    limitMock.mockResolvedValue({ success: true });
+    summarizeMock.mockResolvedValue("CTO summary");
+    upsertEmbeddingMock.mockResolvedValue(undefined);
+
+    const payload = {
+      role: "CTO" as const,
+      structured: {
+        name: "Bob",
+        location: "SF",
+        primary_stack: "TypeScript",
+        years_experience: "6",
+        domains: "FinTech",
+        track_record: "Scaled payments infra",
+      },
+      freeText: "Looking for a visionary CEO.",
+    };
+
+    const request = new Request("http://localhost/api/interview/submit", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+
+    const techBackground = await prisma.techBackground.findUnique({ where: { userId: user.id } });
+    expect(techBackground).toMatchObject({
+      primary_stack: "TypeScript",
+      years_experience: 6,
+      domains: "FinTech",
+      track_record: "Scaled payments infra",
+    });
+
+    const userRecord = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(userRecord?.onboarded).toBe(true);
+
+    expect(summarizeMock).toHaveBeenCalledWith({
+      role: "CTO",
+      structured: payload.structured,
+      freeText: payload.freeText,
+    });
+    expect(upsertEmbeddingMock).toHaveBeenCalledWith(user.id, "CTO", "CTO summary", "summary");
+  });
+});
+
+

--- a/tests/integration/api-match-preview.test.ts
+++ b/tests/integration/api-match-preview.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  getTestPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from "../helpers/db";
+
+const hasDatabaseUrl = Boolean(process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL);
+const describeIfDatabaseConfigured = hasDatabaseUrl ? describe : describe.skip;
+
+const prismaHolder: { prisma: PrismaClient | null } = { prisma: null };
+const authMock = vi.fn();
+const limitMock = vi.fn();
+const findMatchesMock = vi.fn();
+const buildRationaleMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  get prisma() {
+    if (!prismaHolder.prisma) {
+      throw new Error("Prisma client requested before test database setup.");
+    }
+    return prismaHolder.prisma;
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  auth: () => authMock(),
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  limit: (key: string, kind?: "auth" | "api") => limitMock(key, kind),
+}));
+
+vi.mock("@/lib/match", () => ({
+  findMatchesFor: (...args: Parameters<typeof findMatchesMock>) => findMatchesMock(...args),
+}));
+
+vi.mock("@/lib/ai", () => ({
+  buildMatchRationale: (...args: Parameters<typeof buildRationaleMock>) =>
+    buildRationaleMock(...args),
+}));
+
+describeIfDatabaseConfigured("POST /api/match/preview", () => {
+  let handler: typeof import("@/app/api/match/preview/route").POST;
+
+  beforeAll(async () => {
+    const { prisma } = await setupTestDatabase();
+    prismaHolder.prisma = prisma;
+    ({ POST: handler } = await import("@/app/api/match/preview/route"));
+  }, 60000);
+
+  afterEach(async () => {
+    authMock.mockReset();
+    limitMock.mockReset();
+    findMatchesMock.mockReset();
+    buildRationaleMock.mockReset();
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    prismaHolder.prisma = null;
+    await teardownTestDatabase();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+    limitMock.mockResolvedValue({ success: true });
+
+    const response = await handler();
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({ data: { email: "ceo@example.com", role: "CEO" } });
+    await prisma.profileSummary.create({
+      data: { userId: user.id, ai_summary_text: "CEO summary" },
+    });
+
+    authMock.mockResolvedValue({ userId: user.id, role: "CEO" });
+    limitMock.mockResolvedValue({ success: false });
+
+    const response = await handler();
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "Rate limit" });
+  });
+
+  it("returns enriched matches with rationale and profile details", async () => {
+    const prisma = getTestPrismaClient();
+    const ceo = await prisma.user.create({
+      data: { email: "ceo@example.com", role: "CEO" },
+    });
+    await prisma.profileSummary.create({
+      data: { userId: ceo.id, ai_summary_text: "CEO summary" },
+    });
+
+    const cto1 = await prisma.user.create({
+      data: {
+        email: "cto1@example.com",
+        role: "CTO",
+        profile: {
+          create: { name: "CTO One", location: "NYC", timezone: "EST", availability: "Full-time", commitment: "High" },
+        },
+        techBackground: {
+          create: {
+            primary_stack: "React",
+            years_experience: 7,
+            domains: "SaaS",
+            track_record: "Built SaaS platforms",
+          },
+        },
+      },
+    });
+    await prisma.profileSummary.create({
+      data: { userId: cto1.id, ai_summary_text: "CTO One summary" },
+    });
+
+    const cto2 = await prisma.user.create({
+      data: {
+        email: "cto2@example.com",
+        role: "CTO",
+        profile: {
+          create: { name: "CTO Two", location: "SF" },
+        },
+        techBackground: {
+          create: {
+            primary_stack: "Node.js",
+            years_experience: 5,
+            domains: "FinTech",
+            track_record: "Built payments systems",
+          },
+        },
+      },
+    });
+    await prisma.profileSummary.create({
+      data: { userId: cto2.id, ai_summary_text: "CTO Two summary" },
+    });
+
+    authMock.mockResolvedValue({ userId: ceo.id, role: "CEO" });
+    limitMock.mockResolvedValue({ success: true });
+    findMatchesMock.mockResolvedValue([
+      { userId: cto1.id, score: 0.95 },
+      { userId: cto2.id, score: 0.85 },
+    ]);
+    buildRationaleMock.mockResolvedValue("Great fit");
+
+    const response = await handler();
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload).toEqual({
+      matches: [
+        expect.objectContaining({
+          userId: cto1.id,
+          score: 0.95,
+          rationale: "Great fit",
+          name: "CTO One",
+          location: "NYC",
+          techBackground: expect.objectContaining({
+            primary_stack: "React",
+            years_experience: 7,
+          }),
+        }),
+        expect.objectContaining({
+          userId: cto2.id,
+          score: 0.85,
+          rationale: "Great fit",
+          name: "CTO Two",
+          techBackground: expect.objectContaining({
+            primary_stack: "Node.js",
+            years_experience: 5,
+          }),
+        }),
+      ],
+    });
+
+    expect(findMatchesMock).toHaveBeenCalledWith(ceo.id, "CEO");
+    expect(buildRationaleMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+

--- a/tests/integration/api-user-role.test.ts
+++ b/tests/integration/api-user-role.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  getTestPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from "../helpers/db";
+
+const hasDatabaseUrl = Boolean(process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL);
+const describeIfDatabaseConfigured = hasDatabaseUrl ? describe : describe.skip;
+
+const prismaHolder: { prisma: PrismaClient | null } = { prisma: null };
+const authMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  get prisma() {
+    if (!prismaHolder.prisma) {
+      throw new Error("Prisma client requested before test database setup.");
+    }
+    return prismaHolder.prisma;
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  auth: () => authMock(),
+}));
+
+describeIfDatabaseConfigured("POST /api/user/role", () => {
+  let handler: typeof import("@/app/api/user/role/route").POST;
+
+  beforeAll(async () => {
+    const { prisma } = await setupTestDatabase();
+    prismaHolder.prisma = prisma;
+    ({ POST: handler } = await import("@/app/api/user/role/route"));
+  }, 60000);
+
+  afterEach(async () => {
+    authMock.mockReset();
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    prismaHolder.prisma = null;
+    await teardownTestDatabase();
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    authMock.mockResolvedValue(null);
+
+    const request = new Request("http://localhost/api/user/role", {
+      method: "POST",
+      body: JSON.stringify({ role: "CEO" }),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 400 when the provided role is invalid", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({
+      data: { email: "member@example.com", role: "CEO" },
+    });
+
+    authMock.mockResolvedValue({ userId: user.id });
+
+    const request = new Request("http://localhost/api/user/role", {
+      method: "POST",
+      body: JSON.stringify({ role: "FOUNDER" }),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid role" });
+
+    const persisted = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(persisted?.role).toBe("CEO");
+  });
+
+  it("updates the user role when the request is valid", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({
+      data: { email: "member@example.com", role: "CEO" },
+    });
+
+    authMock.mockResolvedValue({ userId: user.id });
+
+    const request = new Request("http://localhost/api/user/role", {
+      method: "POST",
+      body: JSON.stringify({ role: "CTO" }),
+    });
+
+    const response = await handler(request);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+
+    const updated = await prisma.user.findUnique({ where: { id: user.id } });
+    expect(updated?.role).toBe("CTO");
+  });
+});
+
+


### PR DESCRIPTION
## Description

This PR implements add integration coverage for key APIs.

**Key changes:**
- add integration coverage for key APIs

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/integration/api-interview-submit.test.ts
- tests/integration/api-match-preview.test.ts
- tests/integration/api-user-role.test.ts

### Statistics
```
tests/integration/api-interview-submit.test.ts | 217 +++++++++++++++++++++++++
 tests/integration/api-match-preview.test.ts    | 185 +++++++++++++++++++++
 tests/integration/api-user-role.test.ts        | 104 ++++++++++++
 3 files changed, 506 insertions(+)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds integration tests covering auth, rate limits, persistence, and responses for key API endpoints.
> 
> - **Integration Tests**
>   - **`POST /api/interview/submit` (`tests/integration/api-interview-submit.test.ts`)**
>     - Verifies 401 for unauthenticated and 429 on rate limit.
>     - Persists CEO/CTO interview data, updates related models (`profile`, `startup`, `techBackground`, `profileSummary`), sets `user.onboarded`.
>     - Asserts AI summary generation and embedding upsert calls.
>   - **`POST /api/match/preview` (`tests/integration/api-match-preview.test.ts`)**
>     - Verifies 401 unauthorized and 429 rate limit.
>     - Returns enriched matches with rationale and profile/tech details; asserts matching and rationale builder calls.
>   - **`POST /api/user/role` (`tests/integration/api-user-role.test.ts`)**
>     - Verifies 401 when unauthenticated.
>     - Validates role input (400 on invalid) and updates role (200 on success).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5eef7964617305e1808ead3e7ac2bc00f409ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->