### PR TITLE
test: cover embedding generation and upsert

### DIFF
--- a/tests/unit/lib/embeddings.test.ts
+++ b/tests/unit/lib/embeddings.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaCreateMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    embedding: {
+      create: prismaCreateMock,
+    },
+  },
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+async function loadModuleWithOpenAI({
+  apiKey = "test-key",
+  embeddingVector = [0.1, 0.2, 0.3],
+}: {
+  apiKey?: string | null;
+  embeddingVector?: number[];
+} = {}) {
+  await vi.resetModules();
+  prismaCreateMock.mockReset();
+
+  restoreEnv();
+  if (apiKey) {
+    process.env.OPENAI_API_KEY = apiKey;
+  } else {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  const createMock = vi.fn().mockResolvedValue({
+    data: [{ embedding: embeddingVector }],
+  });
+  const ctorMock = vi.fn();
+
+  vi.doMock("openai", () => ({
+    default: class MockOpenAI {
+      embeddings = { create: createMock };
+      constructor(config: { apiKey: string }) {
+        ctorMock(config);
+      }
+    },
+  }));
+
+  const mod = await import("@/lib/embeddings");
+  return { ...mod, createMock, ctorMock };
+}
+
+describe("embed", () => {
+  beforeEach(async () => {
+    await vi.resetModules();
+    prismaCreateMock.mockReset();
+    restoreEnv();
+  });
+
+  it("returns empty Uint8Array when OPENAI_API_KEY is missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { embed } = await import("@/lib/embeddings");
+    const result = await embed("hello world");
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.byteLength).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPENAI_API_KEY not configured")
+    );
+  });
+
+  it("generates embeddings when API key present", async () => {
+    const { embed, createMock, ctorMock } = await loadModuleWithOpenAI({
+      apiKey: "present",
+      embeddingVector: [0.25, -0.5],
+    });
+
+    const result = await embed("generate embedding");
+
+    expect(ctorMock).toHaveBeenCalledWith({ apiKey: "present" });
+    expect(createMock).toHaveBeenCalledWith({
+      model: "text-embedding-3-small",
+      input: "generate embedding",
+    });
+    expect(result).toBeInstanceOf(Uint8Array);
+    // Float32Array of length 2 -> 8 bytes backing buffer
+    expect(result.byteLength).toBe(8);
+  });
+});
+
+describe("upsertEmbedding", () => {
+  beforeEach(async () => {
+    await vi.resetModules();
+    prismaCreateMock.mockReset();
+    restoreEnv();
+  });
+
+  it("skips upsert when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { upsertEmbedding } = await import("@/lib/embeddings");
+
+    await upsertEmbedding("user-1", "CEO", "text", "summary");
+
+    expect(prismaCreateMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPENAI_API_KEY not configured")
+    );
+  });
+
+  it("skips upsert when embedding result is empty", async () => {
+    const { upsertEmbedding, createMock } = await loadModuleWithOpenAI({
+      embeddingVector: [],
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await upsertEmbedding("user-2", "CTO", "text", "summary");
+
+    expect(createMock).toHaveBeenCalled();
+    expect(prismaCreateMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Embedding generation returned empty result")
+    );
+  });
+
+  it("writes embedding to prisma when generation succeeds", async () => {
+    const { upsertEmbedding, createMock } = await loadModuleWithOpenAI({
+      embeddingVector: [0.1, 0.2, 0.3],
+    });
+
+    await upsertEmbedding("user-3", "CEO", "profile summary", "summary");
+
+    expect(createMock).toHaveBeenCalled();
+    expect(prismaCreateMock).toHaveBeenCalledWith({
+      data: {
+        userId: "user-3",
+        role: "CEO",
+        source: "summary",
+        vector: expect.any(Buffer),
+      },
+    });
+    const bufferArg = (prismaCreateMock.mock.calls[0] as any)[0].data.vector as Buffer;
+    const floatArray = new Float32Array(bufferArg.buffer, bufferArg.byteOffset, bufferArg.byteLength / 4);
+    const parsed = Array.from(floatArray);
+    expect(parsed[0]).toBeCloseTo(0.1, 6);
+    expect(parsed[1]).toBeCloseTo(0.2, 6);
+    expect(parsed[2]).toBeCloseTo(0.3, 6);
+  });
+});
+
+afterAll(() => {
+  restoreEnv();
+});
+


### PR DESCRIPTION
## Description

This PR implements cover embedding generation and upsert.

**Key changes:**
- cover embedding generation and upsert
- add unit coverage for findMatchesFor (#32)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/unit/lib/embeddings.test.ts
- tests/unit/lib/match.test.ts

### Statistics
```
tests/unit/lib/embeddings.test.ts | 157 ++++++++++++++++++++++++++++++++++++++
 tests/unit/lib/match.test.ts      | 112 +++++++++++++++++++++++++++
 2 files changed, 269 insertions(+)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add unit tests for embedding generation and upsert behavior, including env handling and Prisma/OpenAI interactions.
> 
> - **Tests**:
>   - **`tests/unit/lib/embeddings.test.ts`**:
>     - Cover `embed`:
>       - Returns empty `Uint8Array` and warns when `OPENAI_API_KEY` missing.
>       - Calls OpenAI with model `text-embedding-3-small` and returns bytes when key present.
>     - Cover `upsertEmbedding`:
>       - Skips and warns when API key missing or embedding result empty.
>       - Persists embedding via `prisma.embedding.create` with buffer-encoded vector on success.
>     - Mocks `openai` client and Prisma; resets modules/env between tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf4086dc08f4838c4049f4a2e4e16898168a7ff1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->