### PR TITLE
test: add unit tests for ai helpers

### DIFF
--- a/tests/unit/lib/ai.test.ts
+++ b/tests/unit/lib/ai.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+async function loadModule({
+  apiKey = "test-key",
+  responseText = "summary response",
+  throwError = false,
+}: {
+  apiKey?: string | null;
+  responseText?: string;
+  throwError?: boolean;
+} = {}) {
+  await vi.resetModules();
+  restoreEnv();
+
+  if (apiKey) {
+    process.env.OPENAI_API_KEY = apiKey;
+  } else {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  const createMock = vi.fn().mockImplementation(() => {
+    if (throwError) {
+      throw new Error("API failure");
+    }
+    return { choices: [{ message: { content: responseText } }] };
+  });
+  const ctorMock = vi.fn();
+
+  vi.doMock("openai", () => ({
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: createMock,
+        },
+      };
+      constructor(config: { apiKey: string }) {
+        ctorMock(config);
+      }
+    },
+  }));
+
+  const mod = await import("@/lib/ai");
+  return { ...mod, createMock, ctorMock };
+}
+
+describe("summarizeProfile", () => {
+  beforeEach(async () => {
+    await vi.resetModules();
+    restoreEnv();
+  });
+
+  it("returns empty string when OPENAI_API_KEY missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { summarizeProfile } = await import("@/lib/ai");
+    const result = await summarizeProfile({
+      role: "CEO",
+      structured: { name: "Alice" },
+      freeText: "experienced",
+    });
+
+    expect(result).toBe("");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPENAI_API_KEY not configured; returning empty summary.")
+    );
+  });
+
+  it("calls OpenAI with structured payload and returns content", async () => {
+    const { summarizeProfile, createMock, ctorMock } = await loadModule({
+      responseText: "Short summary",
+    });
+
+    const structured = { name: "Alice", skills: ["Product"] };
+    const result = await summarizeProfile({
+      role: "CEO",
+      structured,
+      freeText: "experienced operator",
+    });
+
+    expect(ctorMock).toHaveBeenCalledWith({ apiKey: "test-key" });
+    expect(createMock).toHaveBeenCalledWith({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: "You are a concise recruiter summarizer." },
+        {
+          role: "user",
+          content: expect.stringContaining('JSON={"name":"Alice","skills":["Product"]} NOTE=experienced operator'),
+        },
+      ],
+      temperature: 0.2,
+    });
+    expect(result).toBe("Short summary");
+  });
+
+  it("returns empty string when OpenAI call throws", async () => {
+    const { summarizeProfile } = await loadModule({
+      throwError: true,
+    });
+
+    const result = await summarizeProfile({
+      role: "CTO",
+      structured: { name: "Bob" },
+    });
+
+    expect(result).toBe("");
+  });
+});
+
+describe("buildMatchRationale", () => {
+  beforeEach(async () => {
+    await vi.resetModules();
+    restoreEnv();
+  });
+
+  it("returns empty string when OPENAI_API_KEY missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { buildMatchRationale } = await import("@/lib/ai");
+    const result = await buildMatchRationale("CEO summary", "CTO summary");
+
+    expect(result).toBe("");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPENAI_API_KEY not configured; skipping match rationale generation.")
+    );
+  });
+
+  it("calls OpenAI with both summaries and returns text", async () => {
+    const { buildMatchRationale, createMock } = await loadModule({
+      responseText: "• Point 1\n• Point 2",
+    });
+
+    const result = await buildMatchRationale("visionary leader", "builder");
+
+    expect(createMock).toHaveBeenCalledWith({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: "Explain the match succinctly in 3 bullet points." },
+        { role: "user", content: "CEO: visionary leader\nCTO: builder" },
+      ],
+      temperature: 0.2,
+    });
+    expect(result).toBe("• Point 1\n• Point 2");
+  });
+
+  it("returns empty string when OpenAI call fails", async () => {
+    const { buildMatchRationale } = await loadModule({ throwError: true });
+
+    const result = await buildMatchRationale("CEO", "CTO");
+
+    expect(result).toBe("");
+  });
+});
+
+afterAll(() => {
+  restoreEnv();
+});
+


### PR DESCRIPTION
## Description

This PR implements add unit tests for ai helpers.

**Key changes:**
- add unit tests for ai helpers

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/unit/lib/ai.test.ts

### Statistics
```
tests/unit/lib/ai.test.ts | 165 ++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 165 insertions(+)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add vitest unit tests for `summarizeProfile` and `buildMatchRationale`, mocking OpenAI and verifying API key handling, payload shape, and error paths.
> 
> - **Tests**:
>   - `tests/unit/lib/ai.test.ts`:
>     - `summarizeProfile`:
>       - Returns empty and warns when `OPENAI_API_KEY` is missing.
>       - Calls OpenAI with structured payload (`model`, `messages`, `temperature`) and returns content.
>       - Returns empty on API error.
>     - `buildMatchRationale`:
>       - Returns empty and warns when `OPENAI_API_KEY` is missing.
>       - Calls OpenAI with both summaries and returns text.
>       - Returns empty on API error.
>     - Mocks `openai` client and asserts constructor `apiKey` and `chat.completions.create` arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f493f56be6d7dbdec191258cdbc92e5e42241991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->