### PR TITLE
test: cover rate limiter fallbacks

### DIFF
--- a/tests/unit/lib/rateLimit.test.ts
+++ b/tests/unit/lib/rateLimit.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLimit = vi.fn();
+const mockSlidingWindow = vi.fn();
+const redisCtor = vi.fn();
+
+vi.mock("@upstash/redis", () => ({
+  Redis: class {
+    constructor(config: { url: string; token: string }) {
+      redisCtor(config);
+    }
+  },
+}));
+
+vi.mock("@upstash/ratelimit", () => ({
+  Ratelimit: class {
+    static slidingWindow = mockSlidingWindow;
+    limit = mockLimit;
+    constructor(options: unknown) {
+      Object.assign(this, options);
+    }
+  },
+}));
+
+function resetEnv() {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
+describe("limit", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetEnv();
+  });
+
+  it("allows requests when redis config missing", async () => {
+    const { limit } = await import("@/lib/rateLimit");
+    const result = await limit("user-key");
+    expect(result).toEqual({ success: true });
+    expect(redisCtor).not.toHaveBeenCalled();
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it("enforces API rate limit when configuration present", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    mockSlidingWindow.mockReturnValue("sliding-window-instance");
+    mockLimit.mockResolvedValue({ success: false, limit: 60 });
+
+    const { limit } = await import("@/lib/rateLimit");
+    const result = await limit("user-key", "api");
+
+    expect(redisCtor).toHaveBeenCalledWith({
+      url: "https://example.com",
+      token: "token",
+    });
+    expect(mockSlidingWindow).toHaveBeenCalledWith(60, "10 m");
+    expect(mockLimit).toHaveBeenCalledWith("user-key");
+    expect(result).toEqual({ success: false, limit: 60 });
+  });
+
+  it("enforces auth limit independently", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    const authLimitMock = vi.fn().mockResolvedValue({ success: true });
+    const apiLimitMock = vi.fn().mockResolvedValue({ success: false });
+
+    mockSlidingWindow.mockImplementation((max: number) => `window-${max}`);
+
+    vi.doMock("@upstash/ratelimit", () => {
+      class MockRatelimit {
+        static slidingWindow = mockSlidingWindow;
+        limit = (key: string) => Promise.resolve({ success: true });
+        constructor(options: { limiter: string; prefix: string }) {
+          if (options.prefix === "ff:auth") {
+            this.limit = authLimitMock;
+          } else {
+            this.limit = apiLimitMock;
+          }
+        }
+      }
+      return { Ratelimit: MockRatelimit };
+    });
+
+    const { limit } = await import("@/lib/rateLimit");
+    await limit("auth-key", "auth");
+    await limit("api-key", "api");
+
+    expect(mockSlidingWindow).toHaveBeenNthCalledWith(1, 5, "10 m");
+    expect(mockSlidingWindow).toHaveBeenNthCalledWith(2, 60, "10 m");
+    expect(authLimitMock).toHaveBeenCalledWith("auth-key");
+    expect(apiLimitMock).toHaveBeenCalledWith("api-key");
+  });
+});
+
+


### PR DESCRIPTION
## Description

This PR implements cover rate limiter fallbacks.

**Key changes:**
- cover rate limiter fallbacks
- add unit tests for ai helpers (#35)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/integration/api-match-preview.test.ts
- tests/unit/lib/ai.test.ts
- tests/unit/lib/rateLimit.test.ts

### Statistics
```
tests/integration/api-match-preview.test.ts |  98 +++++++++--------
 tests/unit/lib/ai.test.ts                   | 165 ++++++++++++++++++++++++++++
 tests/unit/lib/rateLimit.test.ts            |  97 ++++++++++++++++
 3 files changed, 317 insertions(+), 43 deletions(-)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds unit tests for rate limiter covering missing-config fallback, configured enforcement, and separate auth vs API limits using Upstash mocks.
> 
> - **Tests**:
>   - **`tests/unit/lib/rateLimit.test.ts`**:
>     - Verifies allowing requests when `UPSTASH_REDIS_*` config is absent.
>     - Ensures API rate limiting when configuration is present (sliding window and limit calls).
>     - Confirms independent limits for `auth` vs `api` prefixes.
>     - Mocks `@upstash/redis` and `@upstash/ratelimit` to assert constructor/config and limiter behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e2eb6064711cce2ef9df7296a06d1b130bc585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->