### PR TITLE
test: add nextauth callback integration coverage

### DIFF
--- a/tests/integration/auth/nextauth-callbacks.test.ts
+++ b/tests/integration/auth/nextauth-callbacks.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import {
+  getTestPrismaClient,
+  resetDatabase,
+  setupTestDatabase,
+  teardownTestDatabase,
+} from "../../helpers/db";
+
+const hasDatabaseUrl = Boolean(process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL);
+const describeIfDatabaseConfigured = hasDatabaseUrl ? describe : describe.skip;
+
+const prismaHolder: { prisma: PrismaClient | null } = { prisma: null };
+
+vi.mock("next-auth/providers/email", () => ({
+  default: (options: any) => ({
+    id: "email",
+    type: "email",
+    name: "Email",
+    options,
+  }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  get prisma() {
+    if (!prismaHolder.prisma) {
+      throw new Error("Prisma client requested before test database setup.");
+    }
+    return prismaHolder.prisma;
+  },
+}));
+
+describeIfDatabaseConfigured("NextAuth callbacks", () => {
+  type AuthCallbacks = NonNullable<(typeof import("@/auth.config"))["authConfig"]["callbacks"]>;
+  let callbacks: AuthCallbacks;
+
+  beforeAll(async () => {
+    const { prisma } = await setupTestDatabase();
+    prismaHolder.prisma = prisma;
+    const { authConfig } = await import("@/auth.config");
+    callbacks = authConfig.callbacks!;
+  }, 60000);
+
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    prismaHolder.prisma = null;
+    await teardownTestDatabase();
+  });
+
+  it("creates a new user with default CEO role on first sign in", async () => {
+    const prisma = getTestPrismaClient();
+    const result = await callbacks.signIn?.({
+      user: { email: "new-user@example.com" } as any,
+      account: { provider: "email" } as any,
+    } as any);
+
+    expect(result).toBe(true);
+    const user = await prisma.user.findUnique({ where: { email: "new-user@example.com" } });
+    expect(user).not.toBeNull();
+    expect(user?.role).toBe("CEO");
+  });
+
+  it("returns false when email missing in sign in payload", async () => {
+    const result = await callbacks.signIn?.({
+      user: {} as any,
+      account: { provider: "email" } as any,
+    } as any);
+
+    expect(result).toBe(false);
+  });
+
+  it("does not duplicate existing users when signing in again", async () => {
+    const prisma = getTestPrismaClient();
+    const existing = await prisma.user.create({
+      data: { email: "existing@example.com", role: "CTO" },
+    });
+
+    const result = await callbacks.signIn?.({
+      user: { email: "existing@example.com", id: existing.id } as any,
+      account: { provider: "email" } as any,
+    } as any);
+
+    expect(result).toBe(true);
+    const users = await prisma.user.findMany({ where: { email: "existing@example.com" } });
+    expect(users).toHaveLength(1);
+    expect(users[0]?.role).toBe("CTO");
+  });
+
+  it("enriches session with user metadata", async () => {
+    const prisma = getTestPrismaClient();
+    const user = await prisma.user.create({
+      data: {
+        email: "session-user@example.com",
+        role: "CTO",
+        onboarded: true,
+      },
+    });
+
+    const session = await callbacks.session?.({
+      session: { user: {} } as any,
+      token: { email: "session-user@example.com" } as any,
+    } as any);
+
+    expect((session as any).userId).toBe(user.id);
+    expect((session as any).role).toBe("CTO");
+    expect((session as any).onboarded).toBe(true);
+  });
+});
+
+


### PR DESCRIPTION
## Description

This PR implements add nextauth callback integration coverage.

**Key changes:**
- add nextauth callback integration coverage

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/integration/auth/nextauth-callbacks.test.ts

### Statistics
```
tests/integration/auth/nextauth-callbacks.test.ts | 113 ++++++++++++++++++++++
 1 file changed, 113 insertions(+)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add DB-backed integration tests for NextAuth signIn/session callbacks, covering user creation, duplication prevention, and session enrichment.
> 
> - **Tests**:
>   - Add `tests/integration/auth/nextauth-callbacks.test.ts` covering NextAuth `callbacks`:
>     - `signIn` creates new user with default `CEO` role for first-time email sign-in.
>     - `signIn` returns `false` when email is missing.
>     - `signIn` does not create duplicates for existing users.
>     - `session` enriches session with `userId`, `role`, and `onboarded`.
>   - Mocks `next-auth/providers/email` and `@/lib/db`; uses test DB setup/teardown helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24174579d64748f638e88ceb917e5a41d1b2451a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->