### PR TITLE
test(playwright): centralize env bootstrap so that e2e runs stay deterministic

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -70,6 +70,15 @@ npx prisma studio
   This script builds the production bundle, starts `npm run start` on `127.0.0.1:3310`, waits for readiness with `wait-on`, and executes the Playwright landing-page smoke spec with `PLAYWRIGHT_BASE_URL` set automatically. The process is cleaned up for you via shell traps.
 - To skip it temporarily (not recommended), export `SKIP_E2E_SMOKE_CHECK=1`. The pre-push hook respects the same variable.
 
+### Full Playwright Environment
+- Install the required browsers once after cloning:
+  ```bash
+  npx playwright install --with-deps
+  ```
+- Ensure either `TEST_DATABASE_URL` or `DATABASE_URL` points at a throwaway Postgres branch. The Playwright helper automatically mirrors `DATABASE_URL` into `TEST_DATABASE_URL`.
+- When running `npm run test:e2e` manually, make sure the Next.js server is running on `http://127.0.0.1:3310` (use the smoke script above, or `npm run dev -- --hostname 127.0.0.1 --port 3310` for interactive debugging). The Playwright config defaults `PLAYWRIGHT_BASE_URL` to that address if not provided.
+- Artifacts from test runs (traces, videos, screenshots) are written to `tmp/playwright-output/`. Inspect them with `npx playwright show-report`.
+
 
 ### Check Terminal Logs
 Look for these log messages:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import { ensurePlaywrightEnv, getPlaywrightBaseURL } from "./tests/e2e/support/env";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL;
+ensurePlaywrightEnv();
+const baseURL = getPlaywrightBaseURL();
+const isCI = Boolean(process.env.CI);
 
 export default defineConfig({
   testDir: "tests/e2e",
@@ -10,6 +13,7 @@ export default defineConfig({
   },
   retries: process.env.CI ? 1 : 0,
   reporter: [["list"]],
+  workers: isCI ? 2 : undefined,
   use: {
     baseURL,
     trace: "on-first-retry",
@@ -21,6 +25,6 @@ export default defineConfig({
       use: devices["Desktop Chrome"],
     },
   ],
+  outputDir: "tmp/playwright-output",
 });
-
 

--- a/tests/e2e/onboarding-flow.spec.ts
+++ b/tests/e2e/onboarding-flow.spec.ts
@@ -1,29 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { PrismaClient, Role } from "@prisma/client";
-import { config as loadEnv } from "dotenv";
-import path from "node:path";
-import { existsSync } from "node:fs";
+import {
+  ensurePlaywrightEnv,
+  getDatabaseUrl,
+  getPlaywrightBaseURL,
+} from "./support/env";
 
-// Ensure database credentials are available for Prisma inside the Playwright runner.
-const envFiles = [".env.test.local", ".env.test", ".env.local", ".env"];
-for (const file of envFiles) {
-  const resolved = path.resolve(process.cwd(), file);
-  if (existsSync(resolved)) {
-    loadEnv({ path: resolved, override: false });
-  }
-}
+ensurePlaywrightEnv();
 
-const databaseUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
-if (!databaseUrl) {
-  throw new Error(
-    "TEST_DATABASE_URL or DATABASE_URL must be provided for e2e onboarding tests."
-  );
-}
-
-process.env.DATABASE_URL = databaseUrl;
-if (!process.env.TEST_DATABASE_URL) {
-  process.env.TEST_DATABASE_URL = databaseUrl;
-}
+const databaseUrl = getDatabaseUrl();
 
 const prisma = new PrismaClient({
   datasources: { db: { url: databaseUrl } },
@@ -33,7 +18,7 @@ function toVector(values: number[]) {
   return Buffer.from(new Float32Array(values).buffer);
 }
 
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3310";
+const BASE_URL = getPlaywrightBaseURL();
 
 test.describe("Onboarding journeys", () => {
   test.beforeEach(async () => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { ensurePlaywrightEnv } from "./support/env";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL;
-
-test.skip(!baseURL, "Set PLAYWRIGHT_BASE_URL to run e2e smoke tests against a live environment.");
+ensurePlaywrightEnv();
 
 test.describe("Landing page smoke test", () => {
   test("shows hero content and auth links", async ({ page }) => {

--- a/tests/e2e/support/env.ts
+++ b/tests/e2e/support/env.ts
@@ -1,0 +1,53 @@
+import { config as loadEnv } from "dotenv";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+let initialized = false;
+
+const ENV_FILES = [".env.test.local", ".env.test", ".env.local", ".env"];
+const DEFAULT_BASE_URL = "http://127.0.0.1:3310";
+
+export function ensurePlaywrightEnv() {
+  if (initialized) return;
+
+  for (const file of ENV_FILES) {
+    const resolved = path.resolve(process.cwd(), file);
+    if (existsSync(resolved)) {
+      loadEnv({ path: resolved, override: false });
+    }
+  }
+
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? DEFAULT_BASE_URL;
+  process.env.PLAYWRIGHT_BASE_URL = baseUrl;
+  if (!process.env.NEXTAUTH_URL) {
+    process.env.NEXTAUTH_URL = baseUrl;
+  }
+
+  const dbUrl = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error(
+      "TEST_DATABASE_URL or DATABASE_URL must be configured for Playwright tests."
+    );
+  }
+
+  process.env.DATABASE_URL = dbUrl;
+  if (!process.env.TEST_DATABASE_URL) {
+    process.env.TEST_DATABASE_URL = dbUrl;
+  }
+
+  process.env.PRISMA_MIGRATE_NO_ADVISORY_LOCK = "1";
+
+  initialized = true;
+}
+
+export function getPlaywrightBaseURL(): string {
+  ensurePlaywrightEnv();
+  return process.env.PLAYWRIGHT_BASE_URL as string;
+}
+
+export function getDatabaseUrl(): string {
+  ensurePlaywrightEnv();
+  return process.env.DATABASE_URL as string;
+}
+
+


### PR DESCRIPTION
## Description

This PR implements centralize env bootstrap so that e2e runs stay deterministic.

**Key changes:**
- centralize env bootstrap so that e2e runs stay deterministic

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Documentation
- TESTING.md

### Code Changes
- playwright.config.ts
- tests/e2e/onboarding-flow.spec.ts
- tests/e2e/smoke.spec.ts
- tests/e2e/support/env.ts

### Statistics
```
TESTING.md                        |  9 +++++++
 playwright.config.ts              |  8 ++++--
 tests/e2e/onboarding-flow.spec.ts | 31 ++++++-----------------
 tests/e2e/smoke.spec.ts           |  5 ++--
 tests/e2e/support/env.ts          | 53 +++++++++++++++++++++++++++++++++++++++
 5 files changed, 78 insertions(+), 28 deletions(-)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes Playwright env setup via a shared helper, updates specs and config to use it, and adds concise Playwright setup docs and output directory.
> 
> - **E2E/Playwright**:
>   - **Env bootstrap**: Add `tests/e2e/support/env.ts` to load `.env*`, set `PLAYWRIGHT_BASE_URL` (defaults to `http://127.0.0.1:3310`), mirror `DATABASE_URL` into `TEST_DATABASE_URL`, set `NEXTAUTH_URL`, and enable `PRISMA_MIGRATE_NO_ADVISORY_LOCK`.
>   - **Config updates** (`playwright.config.ts`): use `ensurePlaywrightEnv()` and `getPlaywrightBaseURL()`, set `workers` to `2` on CI, and write artifacts to `tmp/playwright-output/`.
>   - **Spec updates**:
>     - `tests/e2e/onboarding-flow.spec.ts`: remove ad-hoc dotenv/env logic; use `ensurePlaywrightEnv()`, `getDatabaseUrl()`, and `getPlaywrightBaseURL()`.
>     - `tests/e2e/smoke.spec.ts`: initialize env via helper and always run against base URL.
> - **Docs** (`TESTING.md`): add "Full Playwright Environment" section with browser install, DB URL guidance, server address defaults, and artifact/report location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb0c7a69d3951caee9158c28f163b20ba53d0e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->