### PR TITLE
test(playwright): add auth flows e2e because login must stay reliable

### DIFF
--- a/tests/e2e/auth/authentication.spec.ts
+++ b/tests/e2e/auth/authentication.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { PrismaClient, Role } from "@prisma/client";
+import {
+  ensurePlaywrightEnv,
+  getPlaywrightBaseURL,
+  getDatabaseUrl,
+} from "../support/env";
+
+ensurePlaywrightEnv();
+
+const BASE_URL = getPlaywrightBaseURL();
+const prisma = new PrismaClient({
+  datasources: { db: { url: getDatabaseUrl() } },
+});
+
+test.describe("Authentication flows", () => {
+  test.beforeEach(async () => {
+    await prisma.$transaction([
+      prisma.session.deleteMany(),
+      prisma.verificationToken.deleteMany(),
+      prisma.account.deleteMany(),
+      prisma.match.deleteMany(),
+      prisma.embedding.deleteMany(),
+      prisma.profileSummary.deleteMany(),
+      prisma.interviewResponse.deleteMany(),
+      prisma.techBackground.deleteMany(),
+      prisma.startup.deleteMany(),
+      prisma.profile.deleteMany(),
+      prisma.user.deleteMany(),
+    ]);
+  });
+
+  test.afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test("allows a new founder to request a sign-up magic link", async ({ page }) => {
+    const uniqueSuffix = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
+    const email = `signup-${uniqueSuffix}@test.founderfinder.com`;
+
+    await page.goto("/auth/signup");
+    await page.getByLabel("Email address").fill(email);
+    await page.getByRole("button", { name: "Continue with email" }).click();
+
+    await expect(page.getByText("Check your email!", { exact: false })).toBeVisible();
+    await expect(page.getByText(email)).toBeVisible();
+
+    const tokenCount = await prisma.verificationToken.count({
+      where: { identifier: email },
+    });
+    expect(tokenCount).toBe(1);
+  });
+
+  test("signs in an onboarded CEO via magic link and supports sign out", async ({
+    page,
+    request,
+  }) => {
+    const email = `ceo-auth-${Date.now()}@test.founderfinder.com`;
+
+    await prisma.user.create({
+      data: {
+        email,
+        role: Role.CEO,
+        onboarded: true,
+        profileSummary: {
+          create: { ai_summary_text: "CEO ready to collaborate." },
+        },
+      },
+    });
+
+    const response = await request.get(
+      `${BASE_URL}/api/test/signin?email=${encodeURIComponent(email)}`
+    );
+    expect(response.ok()).toBeTruthy();
+    const { magicLink } = await response.json();
+    expect(magicLink).toBeTruthy();
+
+    await page.goto(magicLink);
+    await page.waitForURL(/\/matches$/, { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: "Your Matches" })).toBeVisible();
+
+    await page.getByRole("link", { name: "Sign out" }).click();
+    await page.waitForURL(/\/$/, { timeout: 10_000 });
+    await expect(page.getByRole("heading", { name: "FounderFinder" })).toBeVisible();
+  });
+});
+
+


### PR DESCRIPTION
## Description

This PR implements add auth flows e2e because login must stay reliable.

**Key changes:**
- add auth flows e2e because login must stay reliable

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/e2e/auth/authentication.spec.ts

### Statistics
```
tests/e2e/auth/authentication.spec.ts | 88 +++++++++++++++++++++++++++++++++++
 1 file changed, 88 insertions(+)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Playwright e2e tests for signup magic link generation and CEO magic-link sign-in/sign-out with Prisma-backed test setup/cleanup.
> 
> - **Tests (Playwright)**:
>   - Add `tests/e2e/auth/authentication.spec.ts` covering:
>     - New founder signup flow: requests magic link and verifies `verificationToken` creation.
>     - Onboarded CEO sign-in via magic link from `GET /api/test/signin?email=...`, navigates to `'/matches'`, then signs out to home.
>   - Test harness: Prisma client configured via `getDatabaseUrl()`; database cleaned in `beforeEach` via `$transaction`; disconnect in `afterAll`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd7dcd26fa789f73439b53b6e592dce10b5623e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->