### PR TITLE
test(playwright): reuse prisma helpers because onboarding flows need shared reset

### DIFF
--- a/tests/e2e/auth/authentication.spec.ts
+++ b/tests/e2e/auth/authentication.spec.ts
@@ -5,6 +5,7 @@ import {
   getPlaywrightBaseURL,
   getDatabaseUrl,
 } from "../support/env";
+import { resetPrismaForE2E } from "../support/prisma";
 
 ensurePlaywrightEnv();
 
@@ -15,19 +16,7 @@ const prisma = new PrismaClient({
 
 test.describe("Authentication flows", () => {
   test.beforeEach(async () => {
-    await prisma.$transaction([
-      prisma.session.deleteMany(),
-      prisma.verificationToken.deleteMany(),
-      prisma.account.deleteMany(),
-      prisma.match.deleteMany(),
-      prisma.embedding.deleteMany(),
-      prisma.profileSummary.deleteMany(),
-      prisma.interviewResponse.deleteMany(),
-      prisma.techBackground.deleteMany(),
-      prisma.startup.deleteMany(),
-      prisma.profile.deleteMany(),
-      prisma.user.deleteMany(),
-    ]);
+    await resetPrismaForE2E(prisma);
   });
 
   test.afterAll(async () => {

--- a/tests/e2e/onboarding-flow.spec.ts
+++ b/tests/e2e/onboarding-flow.spec.ts
@@ -5,33 +5,22 @@ import {
   getDatabaseUrl,
   getPlaywrightBaseURL,
 } from "./support/env";
+import {
+  resetPrismaForE2E,
+  toVectorBuffer,
+} from "./support/prisma";
 
 ensurePlaywrightEnv();
 
-const databaseUrl = getDatabaseUrl();
-
 const prisma = new PrismaClient({
-  datasources: { db: { url: databaseUrl } },
+  datasources: { db: { url: getDatabaseUrl() } },
 });
-
-function toVector(values: number[]) {
-  return Buffer.from(new Float32Array(values).buffer);
-}
 
 const BASE_URL = getPlaywrightBaseURL();
 
 test.describe("Onboarding journeys", () => {
   test.beforeEach(async () => {
-    await prisma.$transaction([
-      prisma.match.deleteMany(),
-      prisma.embedding.deleteMany(),
-      prisma.profileSummary.deleteMany(),
-      prisma.interviewResponse.deleteMany(),
-      prisma.techBackground.deleteMany(),
-      prisma.startup.deleteMany(),
-      prisma.profile.deleteMany(),
-      prisma.user.deleteMany(),
-    ]);
+    await resetPrismaForE2E(prisma);
   });
 
   test.afterAll(async () => {
@@ -67,7 +56,7 @@ test.describe("Onboarding journeys", () => {
         userId: ceo.id,
         role: Role.CEO,
         source: "summary",
-        vector: toVector([1, 0]),
+        vector: toVectorBuffer([1, 0]),
       },
     });
 
@@ -132,7 +121,7 @@ test.describe("Onboarding journeys", () => {
             create: {
               role: Role.CTO,
               source: "summary",
-              vector: toVector(data.vector),
+              vector: toVectorBuffer(data.vector),
             },
           },
         },
@@ -220,7 +209,7 @@ test.describe("Onboarding journeys", () => {
         userId: cto.id,
         role: Role.CTO,
         source: "summary",
-        vector: toVector([0.9, 0.2]),
+        vector: toVectorBuffer([0.9, 0.2]),
       },
     });
 
@@ -279,7 +268,7 @@ test.describe("Onboarding journeys", () => {
             create: {
               role: Role.CEO,
               source: "summary",
-              vector: toVector(data.vector),
+              vector: toVectorBuffer(data.vector),
             },
           },
         },

--- a/tests/e2e/support/prisma.ts
+++ b/tests/e2e/support/prisma.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from "@prisma/client";
+
+export async function resetPrismaForE2E(prisma: PrismaClient) {
+  await prisma.$transaction([
+    prisma.session.deleteMany(),
+    prisma.verificationToken.deleteMany(),
+    prisma.account.deleteMany(),
+    prisma.match.deleteMany(),
+    prisma.embedding.deleteMany(),
+    prisma.profileSummary.deleteMany(),
+    prisma.interviewResponse.deleteMany(),
+    prisma.techBackground.deleteMany(),
+    prisma.startup.deleteMany(),
+    prisma.profile.deleteMany(),
+    prisma.user.deleteMany(),
+  ]);
+}
+
+export function toVectorBuffer(values: number[]) {
+  return Buffer.from(new Float32Array(values).buffer);
+}
+
+


### PR DESCRIPTION
## Description

This PR implements reuse prisma helpers because onboarding flows need shared reset.

**Key changes:**
- reuse prisma helpers because onboarding flows need shared reset

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### Code Changes
- tests/e2e/auth/authentication.spec.ts
- tests/e2e/onboarding-flow.spec.ts
- tests/e2e/support/prisma.ts

### Statistics
```
tests/e2e/auth/authentication.spec.ts | 15 ++-------------
 tests/e2e/onboarding-flow.spec.ts     | 31 ++++++++++---------------------
 tests/e2e/support/prisma.ts           | 23 +++++++++++++++++++++++
 3 files changed, 35 insertions(+), 34 deletions(-)
```

## Testing
- [x] Tests pass locally ✅ (automated verification)
- [x] CI checks pass ✅ (automated verification)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts shared Prisma E2E helpers and updates Playwright auth/onboarding tests to use centralized DB reset and vector buffer utility.
> 
> - **Tests**:
>   - **Shared helpers** (`tests/e2e/support/prisma.ts`):
>     - Add `resetPrismaForE2E` to centralize DB cleanup.
>     - Add `toVectorBuffer` for embedding vectors.
>   - **Auth/Onboarding specs** (`tests/e2e/auth/authentication.spec.ts`, `tests/e2e/onboarding-flow.spec.ts`):
>     - Replace inline delete transactions with `resetPrismaForE2E`.
>     - Replace local vector helper with `toVectorBuffer` for embeddings.
>     - Simplify Prisma client initialization using `getDatabaseUrl()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34a5d9eb6da49292382a338e1aed1c4c336cd0eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->