### PR TITLE
fix(analytics): add auth check to track endpoint so that unauthenticated users cannot poison metrics

### DIFF
--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { track, type AnalyticsEvent } from "@/lib/analytics";
 
 /**
@@ -6,6 +7,11 @@ import { track, type AnalyticsEvent } from "@/lib/analytics";
  * Can be called from client components to track events server-side
  */
 export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session || !(session as any).userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const event = await req.json();
     


### PR DESCRIPTION
## Summary
- Adds `auth()` session check at the top of `POST /api/analytics/track`
- Unauthenticated requests now receive 401 instead of being processed
- Closes security finding: **MEDIUM missing_auth** — no authentication on analytics track endpoint

## Test plan
- [ ] `POST /api/analytics/track` without session → 401
- [ ] `POST /api/analytics/track` with valid session → normal response

🤖 Generated with [Claude Code](https://claude.com/claude-code)