### PR TITLE
chore(claude): apply insights recommendations to reduce agent friction and encode workflow conventions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,20 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git *)",
+      "Bash(git checkout *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git branch *)",
+      "Bash(git stash *)",
+      "Bash(git log *)",
+      "Bash(git status)",
+      "Bash(git diff *)",
       "Bash(npm run *)",
       "Bash(npx *)",
-      "Bash(gh *)",
+      "Bash(gh pr *)",
+      "Bash(gh auth status)",
       "Edit(**)",
       "Write(**)"
     ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(npm run *)",
+      "Bash(npx *)",
+      "Bash(gh *)",
+      "Edit(**)",
+      "Write(**)"
+    ],
     "deny": [
       "Read(.env*)",
       "Read(*credentials*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Working Style
 
-**Never commit directly to `main` or `master`.** Always create a feature branch and open a PR — even for small fixes. Never use `git commit --no-verify` or bypass hooks.
+**Never commit or push directly to `main` or `master`.** Always create a feature branch and open a PR — even for small fixes. Never use `--no-verify` or bypass hooks. Each branch must focus on a single task — if a description would need "and" to cover multiple changes, use separate branches.
 
 **When asked for step-by-step implementation, do NOT parallelize.** Complete one step at a time and wait for confirmation before proceeding to the next.
 
@@ -37,8 +37,6 @@ npm run ci:local         # Full: npm ci + lint + typecheck
 ```
 
 ## Git Workflow
-
-**Never push directly to main.** Always create a feature branch and open a PR.
 
 **Branch naming (enforced by hooks):** `<type>/<area>-<action>-<context>-<outcome>` (min 24 chars)
 - Examples: `feat/matching-expand-skill-filters-to-unblock-discovery`, `fix/auth-magic-link-copy-to-raise-activation-rate`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,16 @@ npm run ci:verify        # Quick: lint + typecheck (skips npm ci)
 npm run ci:local         # Full: npm ci + lint + typecheck
 ```
 
+## Working Style
+
+**Never commit directly to `main` or `master`.** Always create a feature branch and open a PR — even for small fixes.
+
+**When asked for step-by-step implementation, do NOT parallelize.** Complete one step at a time and wait for confirmation before proceeding to the next.
+
+**Always plan before coding.** When starting a non-trivial task, briefly describe the approach and get approval before writing code. Follow existing project conventions and patterns — don't introduce new ones (e.g. Makefiles, hardcoded paths) without discussion.
+
+**Never read, commit, or expose `.env.local` or any dotenv file.** Treat all dotenv files as sensitive, even in examples or documentation.
+
 ## Git Workflow
 
 **Never push directly to main.** Always create a feature branch and open a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Working Style
+
+**Never commit directly to `main` or `master`.** Always create a feature branch and open a PR — even for small fixes. Never use `git commit --no-verify` or bypass hooks.
+
+**When asked for step-by-step implementation, do NOT parallelize.** Complete one step at a time and wait for confirmation before proceeding to the next.
+
+**Always plan before coding.** When starting a non-trivial task, briefly describe the approach and get approval before writing code. Follow existing project conventions and patterns — don't introduce new ones (e.g. Makefiles, hardcoded paths) without discussion.
+
+**Never read, commit, or expose any `.env*` file.** Treat all dotenv files as sensitive, even in examples or documentation.
+
 ## Build & Development Commands
 
 ```bash
@@ -25,16 +35,6 @@ npm run test:e2e:smoke   # Full smoke test (builds, starts server, runs tests)
 npm run ci:verify        # Quick: lint + typecheck (skips npm ci)
 npm run ci:local         # Full: npm ci + lint + typecheck
 ```
-
-## Working Style
-
-**Never commit directly to `main` or `master`.** Always create a feature branch and open a PR — even for small fixes.
-
-**When asked for step-by-step implementation, do NOT parallelize.** Complete one step at a time and wait for confirmation before proceeding to the next.
-
-**Always plan before coding.** When starting a non-trivial task, briefly describe the approach and get approval before writing code. Follow existing project conventions and patterns — don't introduce new ones (e.g. Makefiles, hardcoded paths) without discussion.
-
-**Never read, commit, or expose `.env.local` or any dotenv file.** Treat all dotenv files as sensitive, even in examples or documentation.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

Implements the two highest-impact recommendations from the /insights report:

### 1. CLAUDE.md — Working Style section
Adds four persistent rules so Claude doesn't have to re-learn them each session:
- **No direct commits to main** — always branch + PR
- **No parallelizing step-by-step requests** — wait for confirmation between steps
- **Plan before coding** — describe approach, get approval, follow existing conventions
- **Never touch dotenv files** — treat all `.env*` as sensitive

### 2. `.claude/settings.json` — Sub-agent allow rules
Adds scoped allow rules for `git *`, `npm run *`, `npx *`, `gh *`, `Edit(**)`, `Write(**)` so background agents can execute without waiting for user approval. Deny rules (`.env*`, credentials, secrets) still take precedence and cannot be overridden.

**Root cause this fixes:** Sub-agents spawned for parallel security fixes were all blocked because the session ran in `default` mode — requiring approval for every Edit/Bash call, with no user present to approve.

## What was NOT changed
- No new hooks (separate concern)
- No new skills (separate concern)
- Deny rules unchanged — secrets still protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)